### PR TITLE
restore and fix __dirname for creating file paths on deployed site

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,5 +1,6 @@
 import express from 'express';
-//import path from 'node:path';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Request, Response } from 'express';
 import db from './config/connection.js'
 import { ApolloServer } from '@apollo/server';// Note: Import from @apollo/server-express
@@ -29,10 +30,12 @@ const startApolloServer = async () => {
   ));
 
   if (process.env.NODE_ENV === 'production') {
-    app.use(express.static('../client/dist'));
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+    app.use(express.static(path.join(__dirname, '../../client/dist')));
 
     app.get('*', (_req: Request, res: Response) => {
-      res.sendFile('../client/dist/index.html');
+      res.sendFile(path.join(__dirname, '../../client/dist/index.html'));
     });
   }
 


### PR DESCRIPTION
Properly fixes the __dirname not defined error by creating the property from the deployed URL paths.
Should fix the internal server error when retreiving /MySeedBox on the deployed site